### PR TITLE
Eco 1268 - clean up test deployment functions

### DIFF
--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -95,13 +95,6 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     }
 
     /**
-     * Update the l2TokenBridge address to the correct one
-     */
-    function setL2Bridge(address _l2TokenBridge) external reinitializer(2) {
-        l2TokenBridge = _l2TokenBridge;
-    }
-
-    /**
      * @dev Upgrades the L2ECO token implementation address, by sending
      *      a cross domain message to the L2 Bridge via the L1 Messenger
      * @param _impl L2 contract address.

--- a/contracts/bridge/L2ECOBridge.sol
+++ b/contracts/bridge/L2ECOBridge.sol
@@ -99,13 +99,6 @@ contract L2ECOBridge is IL2ECOBridge, CrossDomainEnabledUpgradeable {
         inflationMultiplier = l2EcoToken.INITIAL_INFLATION_MULTIPLIER();
     }
 
-    // /**
-    //  * Upate the l1TokenBridge address to the correct one
-    //  */
-    // function upgrade1(address _l1TokenBridge) public reinitializer(2) {
-    //     l1TokenBridge = _l1TokenBridge;
-    // }
-
     /**
      * @dev Withdraws tokens from L2 to L1 for the caller
      * @param _l2Token L2 token address to withdraw

--- a/contracts/interfaces/bridge/IL1ECOBridge.sol
+++ b/contracts/interfaces/bridge/IL1ECOBridge.sol
@@ -38,12 +38,6 @@ interface IL1ECOBridge is IL1ERC20Bridge {
     ) external;
 
     /**
-     * @dev Sets the L2TokenBridge attribute to the correct address.
-     * @param _l2TokenBridge address of the L2 token bridge
-     */
-    function setL2Bridge(address _l2TokenBridge) external;
-
-    /**
      * @dev Upgrades the L2ECO token implementation address, by sending
      *      a cross domain message to the L2 Bridge via the L1 Messenger
      * @param _impl L2 contract address.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   ],
   "scripts": {
     "test": "hardhat test",
-    "build": "hardhat compile",
+    "coverage": "hardhat coverage",
+    "build": "nvm use && hardhat compile",
     "clean": "hardhat clean",
     "node": "hardhat node",
     "format": "concurrently 'npm:format:*'",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "hardhat test",
     "coverage": "hardhat coverage",
-    "build": "nvm use && hardhat compile",
+    "build": "hardhat compile",
     "clean": "hardhat clean",
     "node": "hardhat node",
     "format": "concurrently 'npm:format:*'",


### PR DESCRIPTION
We don't need these admin-like single use functions for deployment.

Sketch for how deployment can work:

Deploy 3 proxies, 2 on L2 and 1 on L1. The proxy on L1 has InitialBridge.sol as its target. Then on L2 we have one proxy with InitialBridge.sol and the other with TokenInitial.sol. Finally, once each proxy is ready, we upgrade each one to their respective contract now that all the addresses are set.