### PR TITLE
Eco 1277 - use IECO instead of ECO

### DIFF
--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -12,7 +12,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {CrossDomainEnabled} from "@eth-optimism/contracts/libraries/bridge/CrossDomainEnabled.sol";
 import {Lib_PredeployAddresses} from "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
-import {ECO} from "@helix-foundation/currency/contracts/currency/ECO.sol";
+import {IECO} from "@helix-foundation/currency/contracts/currency/IECO.sol";
 import {CrossDomainEnabledUpgradeable} from "./CrossDomainEnabledUpgradeable.sol";
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
@@ -89,7 +89,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
         ecoAddress = _ecoAddress;
         l1ProxyAdmin = ProxyAdmin(_l1ProxyAdmin);
         upgrader = _upgrader;
-        inflationMultiplier = ECO(_ecoAddress).getPastLinearInflation(
+        inflationMultiplier = IECO(_ecoAddress).getPastLinearInflation(
             block.number
         );
     }
@@ -193,7 +193,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     ) external onlyFromCrossDomainAccount(l2TokenBridge) {
         uint256 _amount = _gonsAmount / inflationMultiplier;
 
-        // equivalent to ECO(ecoAddress).transfer(_to, _amount); but is revert safe
+        // equivalent to IECO(ecoAddress).transfer(_to, _amount); but is revert safe
         bytes memory _ecoTransferMessage = abi.encodeWithSelector(
             IERC20.transfer.selector,
             _to,
@@ -241,7 +241,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     }
 
     function rebase(uint32 _l2Gas) external {
-        inflationMultiplier = ECO(ecoAddress).getPastLinearInflation(
+        inflationMultiplier = IECO(ecoAddress).getPastLinearInflation(
             block.number
         );
 
@@ -287,7 +287,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
         // When a deposit is initiated on L1, the L1 Bridge transfers the funds to itself for future
         // withdrawals.
 
-        ECO(_l1Token).transferFrom(_from, address(this), _amount);
+        IECO(_l1Token).transferFrom(_from, address(this), _amount);
         // gons move across the bridge, with inflation multipliers on either side to correctly scale balances
         _amount = _amount * inflationMultiplier;
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/abstract-signer": "^5.7.0",
     "@ethersproject/constants": "^5.7.0",
-    "@helix-foundation/currency": "1.0.4",
+    "@helix-foundation/currency": "1.0.5",
     "dotenv": "^16.0.1",
     "ethers": "^5.6.9",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,10 +780,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@helix-foundation/currency@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@helix-foundation/currency/-/currency-1.0.4.tgz#88b2dd331d4c614d3c48c0761bce96d9778dec7c"
-  integrity sha512-mPrnjVhkTUq3WU8yayuqdcKbiIBpgVWCLfNtGzsHwS+iIKsCXhPGxhGC3rmh+X6SHdymKFDosbO9gN2L+vsbuw==
+"@helix-foundation/currency@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@helix-foundation/currency/-/currency-1.0.5.tgz#db99a24691c8fa759a79794901e4684769795ebd"
+  integrity sha512-UkX7z0wY4pHGUcYAsWDbsdZUtTlCHLj79EBmeeV6fV4GJfiNrKof0EZtQ1m2oJIoUSkEM4/sESl51Aajbj196A==
   dependencies:
     "@ethersproject/experimental" "^5.7.0"
     "@openzeppelin/contracts" "^4.6.0"


### PR DESCRIPTION
required bumping package version for helix-foundation package