### PR TITLE
Eco 1331 - Add comments and remove unused functions

### DIFF
--- a/contracts/bridge/CrossDomainEnabledUpgradeable.sol
+++ b/contracts/bridge/CrossDomainEnabledUpgradeable.sol
@@ -14,7 +14,7 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
  * Compiler used: defined by inheriting contract
  */
 contract CrossDomainEnabledUpgradeable is Initializable {
-    // Messenger contract used to send and recieve messages from the other domain.
+    // Messenger contract used to send and receive messages from the other domain.
     address public messenger;
 
     /**

--- a/contracts/bridge/InitialBridge.sol
+++ b/contracts/bridge/InitialBridge.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-//This bridge exists for being the initial target of the proxy before we have all the addresses to initialize fully
+// This bridge exists for being the initial target of the proxy before we have all the addresses to initialize fully
 contract InitialBridge {
+
+    // this function is for compliance with OZ proxy framework
     function initialize() public {
         // empty
     }

--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -281,7 +281,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
      * @param _l2Token Address of the L2 ECO token contract
      * @param _from Account to pull the deposit from on L1
      * @param _to Account to give the deposit to on L2
-     * @param _amount Amount of ECO to pull and deposit.
+     * @param _amount Amount of ECO being deposited.
      * @param _l2Gas Gas limit required to complete the deposit on L2.
      * @param _data Optional data to forward to L2.
      */

--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -278,18 +278,16 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     }
 
     /**
-     * @dev Performs the logic for deposits by informing the L2 Deposited Token
-     * contract of the deposit and calling a handler to lock the L1 funds. (e.g. transferFrom)
+     * @dev Performs the logic for deposits by informing the L2 ECO token
+     * contract of the deposit and pulling in the L1 funds from the depositor
      *
-     * @param _l1Token Address of the L1 ERC20 we are depositing
-     * @param _l2Token Address of the L1 respective L2 ERC20
+     * @param _l1Token Address of the L1 ECO token contract
+     * @param _l2Token Address of the L2 ECO token contract
      * @param _from Account to pull the deposit from on L1
      * @param _to Account to give the deposit to on L2
-     * @param _amount Amount of the ERC20 to deposit.
+     * @param _amount Amount of ECO to pull and deposit.
      * @param _l2Gas Gas limit required to complete the deposit on L2.
-     * @param _data Optional data to forward to L2. This data is provided
-     *        solely as a convenience for external contracts. Aside from enforcing a maximum
-     *        length, these contracts provide no guarantees about its content.
+     * @param _data Optional data to forward to L2.
      */
     function _initiateERC20Deposit(
         address _l1Token,

--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -66,8 +66,8 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
 
     /**
      * Disable the implementation contract
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
-    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }
@@ -99,10 +99,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     }
 
     /**
-     * @dev Upgrades the L2ECO token implementation address, by sending
-     *      a cross domain message to the L2 Bridge via the L1 Messenger
-     * @param _impl L2 contract address.
-     * @param _l2Gas Gas limit for the L2 message.
+     * @inheritdoc IL1ECOBridge
      * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
     function upgradeECO(address _impl, uint32 _l2Gas)
@@ -120,10 +117,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     }
 
     /**
-     * @dev Upgrades the L2ECOBridge implementation address, by sending
-     *      a cross domain message to the L2 Bridge via the L1 Messenger
-     * @param _impl L2 contract address.
-     * @param _l2Gas Gas limit for the L2 message.
+     * @inheritdoc IL1ECOBridge
      * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
     function upgradeL2Bridge(address _impl, uint32 _l2Gas)
@@ -140,9 +134,8 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
         emit UpgradeL2Bridge(_impl);
     }
 
-    /**
-     * @dev Upgrades this contract implementation by passing the new implementation address to the ProxyAdmin.
-     * @param _newBridgeImpl The new L1ECOBridge implementation address.
+     /**
+     * @inheritdoc IL1ECOBridge
      * @custom:oz-upgrades-unsafe-allow-reachable delegatecall
      */
     function upgradeSelf(address _newBridgeImpl) external virtual onlyUpgrader {
@@ -202,6 +195,8 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
 
     /**
      * @inheritdoc IL1ERC20Bridge
+     * @param _l1Token Ignores this input, only services the ECO L1 token address.
+     * @param _l2Token Does not ignore this value, but only accepts the stored l2Bridge
      */
     function finalizeERC20Withdrawal(
         address _l1Token,

--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.19;
 import {IL1ECOBridge} from "../interfaces/bridge/IL1ECOBridge.sol";
 import {IL2ECOBridge} from "../interfaces/bridge/IL2ECOBridge.sol";
 import {IL2ERC20Bridge} from "@eth-optimism/contracts/L2/messaging/IL2ERC20Bridge.sol";
+import {IL1ERC20Bridge} from "@eth-optimism/contracts/L1/messaging/IL1ERC20Bridge.sol";
 import {L2ECOBridge} from "../bridge/L2ECOBridge.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -52,6 +53,9 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
         _;
     }
 
+    /**
+     * @dev Modifier for gating upgrade functionality behind an authorized ECO protocol governace contract
+     */
     modifier onlyUpgrader() {
         require(
             msg.sender == upgrader,
@@ -154,6 +158,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     }
 
     /**
+     * @inheritdoc IL1ERC20Bridge
      */
     function depositERC20(
         address,//_l1Token
@@ -174,6 +179,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     }
 
     /**
+     * @inheritdoc IL1ERC20Bridge
      */
     function depositERC20To(
         address,//_l1Token
@@ -195,7 +201,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     }
 
     /**
-     * When a withdrawal is finalized on L1, the L1 Bridge transfers the funds to the withdrawer
+     * @inheritdoc IL1ERC20Bridge
      */
     function finalizeERC20Withdrawal(
         address _l1Token,
@@ -254,6 +260,9 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
         }
     }
 
+    /**
+     * @inheritdoc IL1ECOBridge
+     */
     function rebase(uint32 _l2Gas) external {
         inflationMultiplier = IECO(ecoAddress).getPastLinearInflation(
             block.number
@@ -266,14 +275,6 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
 
         sendCrossDomainMessage(l2TokenBridge, _l2Gas, message);
     }
-
-    /**
-     * @dev Adds ETH balance to the account. This is meant to allow for ETH
-     * to be migrated from an old gateway to a new gateway.
-     * NOTE: This is left for one upgrade only so we are able to receive the migrated ETH from the
-     * old contract
-     */
-    function donateETH() external payable {}
 
     /**
      * @dev Performs the logic for deposits by informing the L2 Deposited Token

--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -20,16 +20,22 @@ import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.s
 
 /**
  * @title L1ECOBridge
- * @dev The L1 ETH and ERC20 Bridge is a contract which stores deposited L1 funds and standard
- * tokens that are in use on L2. It synchronizes a corresponding L2 Bridge, informing it of deposits
+ * @dev The L1 ECO Bridge is a contract which stores deposited L1 ECO
+ * that is in use on L2. It synchronizes a corresponding L2 Bridge, informing it of deposits
  * and listening to it for newly finalized withdrawals.
- *
+ * It also acts as the authorized source of L1 governance decisions as seen by the L2.
+ * All governance related data and decisions are passed through this contract so that the
+ * L2 contracts can maintain and trust a single source of L1 messages.
  */
 contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
-    // L2 side of the bridge
+    /**
+     * @dev L2 side of the bridge
+     */
     address public l2TokenBridge;
 
-    // L1 ECO address
+    /**
+     * @dev L1 ECO address
+     */
     address public ecoAddress;
 
     /**
@@ -37,10 +43,14 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
      */
     ProxyAdmin public l1ProxyAdmin;
 
-    // L2 upgrader role
+    /**
+     * @dev L2 upgrader role
+     */
     address public upgrader;
 
-    // Current inflation multiplier
+    /**
+     * @dev Current inflation multiplier
+     */
     uint256 public inflationMultiplier;
 
     /**
@@ -73,11 +83,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     }
 
     /**
-     * @param _l1messenger L1 Messenger address being used for cross-chain communications.
-     * @param _l2TokenBridge L2 standard bridge address.
-     * @param _ecoAddress address of L1 ECO contract.
-     * @param _l1ProxyAdmin address of ProxyAdmin contract for the L1 Bridge.
-     * @param _upgrader address that can perform upgrades.
+     * @inheritdoc IL1ECOBridge
      */
     function initialize(
         address _l1messenger,

--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -3,17 +3,13 @@ pragma solidity 0.8.19;
 
 /* Interface Imports */
 import {IL1ECOBridge} from "../interfaces/bridge/IL1ECOBridge.sol";
+import {IL1ERC20Bridge} from "@eth-optimism/contracts/L1/messaging/IL1ERC20Bridge.sol";
 import {IL2ECOBridge} from "../interfaces/bridge/IL2ECOBridge.sol";
 import {IL2ERC20Bridge} from "@eth-optimism/contracts/L2/messaging/IL2ERC20Bridge.sol";
-import {IL1ERC20Bridge} from "@eth-optimism/contracts/L1/messaging/IL1ERC20Bridge.sol";
-import {L2ECOBridge} from "../bridge/L2ECOBridge.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IECO} from "@helix-foundation/currency/contracts/currency/IECO.sol";
 
 /* Library Imports */
-import {CrossDomainEnabled} from "@eth-optimism/contracts/libraries/bridge/CrossDomainEnabled.sol";
-import {Lib_PredeployAddresses} from "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
-import {IECO} from "@helix-foundation/currency/contracts/currency/IECO.sol";
 import {CrossDomainEnabledUpgradeable} from "./CrossDomainEnabledUpgradeable.sol";
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
@@ -59,7 +55,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
      */
     modifier onlyEOA() {
         // Used to stop deposits from contracts (avoid accidentally lost tokens)
-        require(!Address.isContract(msg.sender), "Account not EOA");
+        require(msg.sender.code.length == 0, "Account not EOA");
         _;
     }
 
@@ -114,7 +110,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
         onlyUpgrader
     {
         bytes memory message = abi.encodeWithSelector(
-            L2ECOBridge.upgradeECO.selector,
+            IL2ECOBridge.upgradeECO.selector,
             _impl
         );
 
@@ -132,7 +128,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
         onlyUpgrader
     {
         bytes memory message = abi.encodeWithSelector(
-            L2ECOBridge.upgradeSelf.selector,
+            IL2ECOBridge.upgradeSelf.selector,
             _impl
         );
 
@@ -270,7 +266,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
         );
 
         bytes memory message = abi.encodeWithSelector(
-            L2ECOBridge.rebase.selector,
+            IL2ECOBridge.rebase.selector,
             inflationMultiplier
         );
 
@@ -307,7 +303,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
 
         // Construct calldata for _l2Token.finalizeDeposit(_to, _amount)
         bytes memory message = abi.encodeWithSelector(
-            //call parent interface of IL2ERC20Bridge to get the selector
+            //call parent interface IL2ERC20Bridge to get the selector
             IL2ERC20Bridge.finalizeDeposit.selector,
             _l1Token,
             _l2Token,

--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -8,10 +8,10 @@ import {IL2ECOBridge} from "../interfaces/bridge/IL2ECOBridge.sol";
 import {IL2ERC20Bridge} from "@eth-optimism/contracts/L2/messaging/IL2ERC20Bridge.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IECO} from "@helix-foundation/currency/contracts/currency/IECO.sol";
-
-/* Library Imports */
-import {CrossDomainEnabledUpgradeable} from "./CrossDomainEnabledUpgradeable.sol";
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+/* Contract Imports */
+import {CrossDomainEnabledUpgradeable} from "./CrossDomainEnabledUpgradeable.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /**

--- a/contracts/bridge/L2ECOBridge.sol
+++ b/contracts/bridge/L2ECOBridge.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+/* Interface Imports */
 import {IL1ECOBridge} from "../interfaces/bridge/IL1ECOBridge.sol";
-import {IL2ECOBridge} from "../interfaces/bridge/IL2ECOBridge.sol";
-import {CrossDomainEnabledUpgradeable} from "./CrossDomainEnabledUpgradeable.sol";
-import {L2ECO} from "../token/L2ECO.sol";
 import {IL1ERC20Bridge} from "@eth-optimism/contracts/L1/messaging/IL1ERC20Bridge.sol";
+import {IL2ECOBridge} from "../interfaces/bridge/IL2ECOBridge.sol";
 import {IL2ERC20Bridge} from "@eth-optimism/contracts/L2/messaging/IL2ERC20Bridge.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+/* Contract Imports */
+import {L2ECO} from "../token/L2ECO.sol";
+import {CrossDomainEnabledUpgradeable} from "./CrossDomainEnabledUpgradeable.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
 /**
  * @title L2ECOBridge

--- a/contracts/interfaces/bridge/IL1ECOBridge.sol
+++ b/contracts/interfaces/bridge/IL1ECOBridge.sol
@@ -28,12 +28,13 @@ interface IL1ECOBridge is IL1ERC20Bridge {
 
     /**
      * @param _l1messenger L1 Messenger address being used for cross-chain communications.
-     * @param _l2TokenBridge L2 standard bridge address.
+     * @param _l2TokenBridge L2 ECO bridge address.
      * @param _ecoAddress address of L1 ECO contract.
      * @param _l1ProxyAdmin address of ProxyAdmin contract for the L1 Bridge.
      * @param _upgrader address that can perform upgrades.
      */
-    function initialize(address _l1messenger,
+    function initialize(
+        address _l1messenger,
         address _l2TokenBridge,
         address _ecoAddress,
         address _l1ProxyAdmin,

--- a/contracts/interfaces/bridge/IL1ECOBridge.sol
+++ b/contracts/interfaces/bridge/IL1ECOBridge.sol
@@ -41,12 +41,20 @@ interface IL1ECOBridge is IL1ERC20Bridge {
     ) external;
 
     /**
-     * @dev Upgrades the L2ECO token implementation address, by sending
+     * @dev Upgrades the L2ECO token implementation address by sending
      *      a cross domain message to the L2 Bridge via the L1 Messenger
      * @param _impl L2 contract address.
      * @param _l2Gas Gas limit for the L2 message.
      */
     function upgradeECO(address _impl, uint32 _l2Gas) external;
+
+    /**
+     * @dev Upgrades the L2ECOBridge implementation address by sending
+     *      a cross domain message to the L2 Bridge via the L1 Messenger
+     * @param _impl L2 contract address.
+     * @param _l2Gas Gas limit for the L2 message.
+     */
+    function upgradeL2Bridge(address _impl, uint32 _l2Gas) external;
 
     /**
      * @dev Upgrades this contract implementation by passing the new implementation address to the ProxyAdmin.

--- a/contracts/interfaces/bridge/IL2ECOBridge.sol
+++ b/contracts/interfaces/bridge/IL2ECOBridge.sol
@@ -17,13 +17,14 @@ interface IL2ECOBridge is IL2ERC20Bridge {
     event UpgradeSelf(address _newBridgeImpl);
 
     /**
-     * @dev Initializer that sets the L2 messanger to use, L1 bridge address and the L2 token address
+     * @dev Initializer that sets the L2 messanger to use, L1 bridge address, the L2 token address, and the proxy admin address
      * @param _l2CrossDomainMessenger Cross-domain messenger used by this contract on L2
      * @param _l1TokenBridge Address of the L1 bridge deployed to L1 chain
      * @param _l2EcoToken Address of the L2 ECO token deployed to L2 chain
      * @param _l2ProxyAdmin Address of the L2 proxy admin that manages the upgrade of the L2 token implementation
      */
-    function initialize(address _l2CrossDomainMessenger,
+    function initialize(
+        address _l2CrossDomainMessenger,
         address _l1TokenBridge,
         address _l2EcoToken,
         address _l2ProxyAdmin

--- a/contracts/token/L2ECO.sol
+++ b/contracts/token/L2ECO.sol
@@ -283,16 +283,4 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
         emit BaseValueTransfer(from, to, amount);
         return amount;
     }
-
-    /**
-     * @dev unused hook
-     * @param from address sending the tokens
-     * @param to address recieving the tokens
-     * @param amount the amount of tokens to be transferred
-     */
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal virtual override {}
 }

--- a/contracts/token/L2ECO.sol
+++ b/contracts/token/L2ECO.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import {ERC20Upgradeable} from "./ERC20Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+/* Interface Imports */
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IL2StandardERC20} from "@eth-optimism/contracts/standards/IL2StandardERC20.sol";
+
+/* Contract Imports */
+import {ERC20Upgradeable} from "./ERC20Upgradeable.sol";
+import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
 
 /**
  * @title L2ECO

--- a/contracts/token/L2ECO.sol
+++ b/contracts/token/L2ECO.sol
@@ -6,6 +6,20 @@ import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IL2StandardERC20} from "@eth-optimism/contracts/standards/IL2StandardERC20.sol";
 
+/**
+ * @title L2ECO
+ * @dev The L2 ECO token is all tokens that have been bridge via the L1ECOBridge and L2ECOBridge
+ * It differens in a few key ways from the L1 ECO token:
+ * Balances are not checkpointed.
+ * There is no voting on the L2 and therefore significant gas is saved by not saving balances.
+ * Obviously with no voting, there is no delegation.
+ * Permissions are handled differently.
+ * Instead of updated via governance, there are granular roles gating minting, burning, and rebasing
+ * These roles are stored on the contract instead of managed through ERC1820
+ * Because of this there is no root policy address.
+ * No generational timing.
+ * The token contract trusts the sources of admin actions and doesn't keep any internal timing.
+ */
 contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
     /**
      * @dev Constant for setting the initial inflation multiplier

--- a/contracts/token/L2ECO.sol
+++ b/contracts/token/L2ECO.sol
@@ -60,7 +60,7 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
     /**
      * @dev Event for recording the transfer amounts after _beforeTokenTransfer applies the inflation multiplier
      * @param from Address sending tokens
-     * @param to Address recieving tokens
+     * @param to Address receive tokens
      * @param value This is in the base (unchanging) amounts the currency is stored in (gons)
      */
     event BaseValueTransfer(
@@ -71,7 +71,7 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
 
     /**
      * @dev Event for minted tokens
-     * @param _account Address recieving tokens
+     * @param _account Address receive tokens
      * @param _amount Amount of tokens being created
      */
     event Mint(address indexed _account, uint256 _amount);
@@ -223,7 +223,7 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
 
     /**
      * @dev Mint tokens for an address. Only callable by minter role addresses
-     * @param _to the address to recieve tokens
+     * @param _to the address to receive tokens
      * @param _amount the amount of tokens to be created
      */
     function mint(address _to, uint256 _amount) external onlyMinterRole {
@@ -285,7 +285,7 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
      * @dev overrides the ERC20 hook to account for the rebasing factor in all transactions
      * emits an event showing the base value (ERC20 emits the inputted value)
      * @param from address sending the tokens
-     * @param to address recieving the tokens
+     * @param to address receive the tokens
      * @param amount the amount of tokens to be transferred
      */
     function _beforeTokenTransfer(

--- a/contracts/token/L2ECO.sol
+++ b/contracts/token/L2ECO.sol
@@ -7,54 +7,85 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IL2StandardERC20} from "@eth-optimism/contracts/standards/IL2StandardERC20.sol";
 
 contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
+    /**
+     * @dev Constant for setting the initial inflation multiplier
+     */
     uint256 public constant INITIAL_INFLATION_MULTIPLIER = 1e18;
 
+    /**
+     * @dev Stores the current inflation multiplier
+     */
     uint256 public linearInflationMultiplier;
 
+    /**
+     * @dev Address which has the ability to change permission roles
+     */
     address public tokenRoleAdmin;
 
-    // address of the L1 token contract
+    /**
+     * @dev Address of the L1 token contract
+     */
     address public l1Token;
 
-    // roles to be managed by tokenRoleAdmin
+    /**
+     * @dev Mapping storing contracts able to mint tokens
+     */
     mapping(address => bool) public minters;
+    /**
+     * @dev Mapping storing contracts able to burn tokens
+     */
     mapping(address => bool) public burners;
+    /**
+     * @dev Mapping storing contracts able to rebase the token
+     */
     mapping(address => bool) public rebasers;
 
-    // to be used to record the transfer amounts after _beforeTokenTransfer
-    // these values are the base (unchanging) values the currency is stored in
+    /**
+     * @dev Event for recording the transfer amounts after _beforeTokenTransfer applies the inflation multiplier
+     * @param from Address sending tokens
+     * @param to Address recieving tokens
+     * @param value This is in the base (unchanging) amounts the currency is stored in (gons)
+     */
     event BaseValueTransfer(
         address indexed from,
         address indexed to,
         uint256 value
     );
 
-    // event for minted tokens
-    // required for IL2StandardERC20 compliance
+    /**
+     * @dev Event for minted tokens
+     * @param _account Address recieving tokens
+     * @param _amount Amount of tokens being created
+     */
     event Mint(address indexed _account, uint256 _amount);
 
-    // event for burned tokens
-    // required for IL2StandardERC20 compliance
+    /**
+     * @dev Event for burned tokens
+     * @param _account Address losing tokens
+     * @param _amount Amount of tokens being destroyed
+     */
     event Burn(address indexed _account, uint256 _amount);
 
-    /** Fired when notified by L1 of a new inflation multiplier.
-     * Used to calculate values for the rebased token.
+    /** 
+     * @dev Emitted when notified by L1 of a new inflation multiplier.
+     * does not necessarily mean the multiplier changes (can be same as before)
+     * @param inflationMultiplier new inflation multiplier used to calculate values for the rebased token.
      */
     event NewInflationMultiplier(uint256 inflationMultiplier);
 
-    modifier uninitialized() {
-        require(
-            linearInflationMultiplier == 0,
-            "L2ECO: contract has already been initialized"
-        );
-        _;
-    }
-
+    /**
+     * @dev Modifier for checking if the sender is a minter
+     */
     modifier onlyMinterRole() {
         require(minters[msg.sender], "L2ECO: not authorized to mint");
         _;
     }
 
+    /**
+     * @dev Modifier for checking if the sender is allowed to burn
+     * both burners and the message sender can burn
+     * @param _from the address burning tokens
+     */
     modifier onlyBurnerRoleOrSelf(address _from) {
         require(
             _from == msg.sender || burners[msg.sender],
@@ -63,11 +94,17 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
         _;
     }
 
+    /**
+     * @dev Modifier for checking if the sender is a rebaser
+     */
     modifier onlyRebaserRole() {
         require(rebasers[msg.sender], "L2ECO: not authorized to rebase");
         _;
     }
 
+    /**
+     * @dev Modifier for checking if the sender is able to edit roles
+     */
     modifier onlyTokenRoleAdmin() {
         require(
             msg.sender == tokenRoleAdmin,
@@ -78,16 +115,21 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
 
     /**
      * Disable the implementation contract
+     * @custom:oz-upgrades-unsafe-allow constructor
      */
-    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }
 
+    /**
+     * @dev Initializer that sets token information as well as the inital role values and the L1 Token address
+     * @param _l1Token sets the L1 token address that is able to process withdrawals (available for convenience and interface compliance)
+     * @param _l2Bridge sets the bridge to give all permissions to
+     */
     function initialize(
         address _l1Token,
         address _l2Bridge
-    ) public initializer uninitialized {
+    ) public initializer {
         ERC20Upgradeable.__ERC20_init(
             "ECO",
             "ECO"
@@ -100,18 +142,26 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
         tokenRoleAdmin = _l2Bridge;
     }
 
-    /** Access function to determine the token balance held by some address.
+    /** 
+     * @dev Access function to determine the token balance held by some address.
      */
     function balanceOf(address _owner) public view override returns (uint256) {
         return super.balanceOf(_owner) / linearInflationMultiplier;
     }
 
-    /** Returns the total (inflation corrected) token supply
+    /**
+     * @dev Returns the total (inflation corrected) token supply
      */
     function totalSupply() public view override returns (uint256) {
         return super.totalSupply() / linearInflationMultiplier;
     }
 
+    /**
+     * @dev change the minting permissions for an address
+     * only callable by tokenRoleAdmin
+     * @param _key the address to change permissions for
+     * @param _value the new permission. true = can mint, false = cannot mint
+     */
     function updateMinters(address _key, bool _value)
         public
         onlyTokenRoleAdmin
@@ -119,6 +169,12 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
         minters[_key] = _value;
     }
 
+    /**
+     * @dev change the burning permissions for an address
+     * only callable by tokenRoleAdmin
+     * @param _key the address to change permissions for
+     * @param _value the new permission. true = can burn, false = cannot burn
+     */
     function updateBurners(address _key, bool _value)
         public
         onlyTokenRoleAdmin
@@ -126,6 +182,12 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
         burners[_key] = _value;
     }
 
+    /**
+     * @dev change the rebasing permissions for an address
+     * only callable by tokenRoleAdmin
+     * @param _key the address to change permissions for
+     * @param _value the new permission. true = can rebase, false = cannot rebase
+     */
     function updateRebasers(address _key, bool _value)
         public
         onlyTokenRoleAdmin
@@ -133,15 +195,30 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
         rebasers[_key] = _value;
     }
 
+    /**
+     * @dev give the role admin privilege to another address
+     * only callable by tokenRoleAdmin
+     * @param _newAdmin the address to be the new admin
+     */
     function updateTokenRoleAdmin(address _newAdmin) public onlyTokenRoleAdmin {
         tokenRoleAdmin = _newAdmin;
     }
 
+    /**
+     * @dev Mint tokens for an address. Only callable by minter role addresses
+     * @param _to the address to recieve tokens
+     * @param _amount the amount of tokens to be created
+     */
     function mint(address _to, uint256 _amount) external onlyMinterRole {
         _mint(_to, _amount);
         emit Mint(_to, _amount);
     }
 
+    /**
+     * @dev Burn tokens for an address. Only callable by burner role addresses
+     * @param _from the address to lose tokens
+     * @param _amount the amount of tokens to be destroyed
+     */
     function burn(address _from, uint256 _amount)
         external
         onlyBurnerRoleOrSelf(_from)
@@ -150,6 +227,10 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
         emit Burn(_from, _amount);
     }
 
+    /**
+     * @dev Rebase tokens for all addresses. Done by changing the inflation multiplier. Only callable by rebaser role addresses
+     * @param _newLinearInflationMultiplier the new inflation multiplier to replace the current one
+     */
     function rebase(uint256 _newLinearInflationMultiplier)
         external
         onlyRebaserRole
@@ -158,6 +239,11 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
         emit NewInflationMultiplier(_newLinearInflationMultiplier);
     }
 
+    /**
+     * @dev function to utilize ERC165 to signal compliance to an Optimism network system
+     * IERC165 and IL2StandardERC20 are the supported interfaces
+     * @param _interfaceId the ID hash of the interface
+     */
     function supportsInterface(bytes4 _interfaceId)
         external
         pure
@@ -170,23 +256,40 @@ contract L2ECO is ERC20Upgradeable, EIP712Upgradeable, IERC165 {
             _interfaceId == secondSupportedInterface;
     }
 
+    /**
+     * @dev helper function for rebases. overwrites the old inflation multiplier with the new one
+     * @param _newLinearInflationMultiplier the new inflation multiplier to replace the current one
+     */
     function _rebase(uint256 _newLinearInflationMultiplier) internal {
         linearInflationMultiplier = _newLinearInflationMultiplier;
     }
 
-    // this function converts to gons for the sake of transferring
+    /**
+     * @dev overrides the ERC20 hook to account for the rebasing factor in all transactions
+     * emits an event showing the base value (ERC20 emits the inputted value)
+     * @param from address sending the tokens
+     * @param to address recieving the tokens
+     * @param amount the amount of tokens to be transferred
+     */
     function _beforeTokenTransfer(
         address from,
         address to,
         uint256 amount
     ) internal virtual override returns(uint256) {
         amount = super._beforeTokenTransfer(from, to, amount);
+        // overwrite for efficiency
         amount = amount * linearInflationMultiplier;
 
         emit BaseValueTransfer(from, to, amount);
         return amount;
     }
 
+    /**
+     * @dev unused hook
+     * @param from address sending the tokens
+     * @param to address recieving the tokens
+     * @param amount the amount of tokens to be transferred
+     */
     function _afterTokenTransfer(
         address from,
         address to,


### PR DESCRIPTION
every function has a natspec docstring comment

there were a few useless and unused functions: donateETH and afterTokenTransfer that were removed

acceptsInterface is a candidate for removal as well