### PR TITLE
Failed upgrade calls

### DIFF
--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -142,7 +142,8 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     {
         bytes memory message = abi.encodeWithSelector(
             IL2ECOBridge.upgradeECO.selector,
-            _impl
+            _impl,
+            block.number
         );
 
         sendCrossDomainMessage(l2TokenBridge, _l2Gas, message);
@@ -160,7 +161,8 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     {
         bytes memory message = abi.encodeWithSelector(
             IL2ECOBridge.upgradeSelf.selector,
-            _impl
+            _impl,
+            block.number
         );
 
         sendCrossDomainMessage(l2TokenBridge, _l2Gas, message);

--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -302,7 +302,8 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
 
         bytes memory message = abi.encodeWithSelector(
             IL2ECOBridge.rebase.selector,
-            inflationMultiplier
+            inflationMultiplier,
+            block.number
         );
 
         sendCrossDomainMessage(l2TokenBridge, _l2Gas, message);

--- a/contracts/interfaces/bridge/IL2ECOBridge.sol
+++ b/contracts/interfaces/bridge/IL2ECOBridge.sol
@@ -34,9 +34,10 @@ interface IL2ECOBridge is IL2ERC20Bridge {
 
     /**
      * @dev Passes the inflation multiplier to the L2Eco token.
-     * @param _inflationMultiplier The inflation multiplier to rebase the
+     * @param _inflationMultiplier The inflation multiplier to rebase the token with
+     * @param _blockNumber The block number of the L1 call that initiated the rebase. Used to prevent replay attacks on failed rebase calls
      */
-    function rebase(uint256 _inflationMultiplier) external;
+    function rebase(uint256 _inflationMultiplier, uint256 _blockNumber) external;
 
     /**
      * @dev Sets the L2ECO token proxy to a new implementation address for the L2ECO token.

--- a/contracts/interfaces/bridge/IL2ECOBridge.sol
+++ b/contracts/interfaces/bridge/IL2ECOBridge.sol
@@ -41,12 +41,14 @@ interface IL2ECOBridge is IL2ERC20Bridge {
     /**
      * @dev Sets the L2ECO token proxy to a new implementation address for the L2ECO token.
      * @param _newEcoImpl The address of the new L2ECO token implementation
+     * @param _blockNumber The block number of the L1 call that initiated the upgrade. Used to prevent replay attacks on failed upgrade calls
      */
-    function upgradeECO(address _newEcoImpl) external;
+    function upgradeECO(address _newEcoImpl, uint256 _blockNumber) external;
 
     /**
      * @dev Upgrades this contract implementation by passing the new implementation address to the ProxyAdmin.
      * @param _newBridgeImpl The new L2ECOBridge implementation address.
+     * @param _blockNumber The block number of the L1 call that initiated the upgrade. Used to prevent replay attacks on failed upgrade calls
      */
-    function upgradeSelf(address _newBridgeImpl) external;
+    function upgradeSelf(address _newBridgeImpl, uint256 _blockNumber) external;
 }

--- a/test/L1ECOBridge.spec.ts
+++ b/test/L1ECOBridge.spec.ts
@@ -485,7 +485,7 @@ describe('L1ECOBridge', () => {
           },
         ])
       }
-      await L1ECOBridge.connect(alice).rebase(FINALIZATION_GAS)
+      const tx = await L1ECOBridge.connect(alice).rebase(FINALIZATION_GAS)
       expect(await L1ECOBridge.inflationMultiplier()).to.eq(
         newInflationMultiplier
       )
@@ -496,7 +496,7 @@ describe('L1ECOBridge', () => {
         DUMMY_L2_BRIDGE_ADDRESS,
         (await getContractInterface('L2ECOBridge')).encodeFunctionData(
           'rebase',
-          [newInflationMultiplier]
+          [newInflationMultiplier, tx.blockNumber]
         ),
         FINALIZATION_GAS,
       ])

--- a/test/L1ECOBridge.spec.ts
+++ b/test/L1ECOBridge.spec.ts
@@ -402,6 +402,7 @@ describe('L1ECOBridge', () => {
         DUMMY_L2_ERC20_ADDRESS,
         FINALIZATION_GAS
       )
+      const blockNumber = await ethers.provider.getBlockNumber()
 
       expect(
         Fake__L1CrossDomainMessenger.sendMessage.getCall(0).args
@@ -409,7 +410,7 @@ describe('L1ECOBridge', () => {
         DUMMY_L2_BRIDGE_ADDRESS,
         (await getContractInterface('L2ECOBridge')).encodeFunctionData(
           'upgradeECO',
-          [DUMMY_L2_ERC20_ADDRESS]
+          [DUMMY_L2_ERC20_ADDRESS, blockNumber]
         ),
         FINALIZATION_GAS,
       ])
@@ -442,6 +443,7 @@ describe('L1ECOBridge', () => {
         DUMMY_L2_BRIDGE_ADDRESS,
         FINALIZATION_GAS
       )
+      const blockNumber = await ethers.provider.getBlockNumber()
 
       expect(
         Fake__L1CrossDomainMessenger.sendMessage.getCall(0).args
@@ -449,7 +451,7 @@ describe('L1ECOBridge', () => {
         DUMMY_L2_BRIDGE_ADDRESS,
         (await getContractInterface('L2ECOBridge')).encodeFunctionData(
           'upgradeSelf',
-          [DUMMY_L2_BRIDGE_ADDRESS]
+          [DUMMY_L2_BRIDGE_ADDRESS, blockNumber]
         ),
         FINALIZATION_GAS,
       ])

--- a/test/L2ECOBridge.spec.ts
+++ b/test/L2ECOBridge.spec.ts
@@ -335,7 +335,10 @@ describe('L2ECOBridge tests', () => {
       )
 
       await expect(
-        L2ECOBridge.connect(l2MessengerImpersonator).rebase(inflationMultiplier, 1)
+        L2ECOBridge.connect(l2MessengerImpersonator).rebase(
+          inflationMultiplier,
+          1
+        )
       )
         .to.emit(L2ECOBridge, 'RebaseInitiated')
         .withArgs(inflationMultiplier)

--- a/test/L2ECOBridge.spec.ts
+++ b/test/L2ECOBridge.spec.ts
@@ -289,7 +289,7 @@ describe('L2ECOBridge tests', () => {
 
   describe('rebase', () => {
     it('onlyFromCrossDomainAccount: should revert on calls from a non-crossDomainMessenger L2 account', async () => {
-      await expect(L2ECOBridge.rebase(2)).to.be.revertedWith(
+      await expect(L2ECOBridge.rebase(2, 1)).to.be.revertedWith(
         ERROR_STRINGS.OVM.INVALID_MESSENGER
       )
     })
@@ -300,7 +300,7 @@ describe('L2ECOBridge tests', () => {
       )
 
       await expect(
-        L2ECOBridge.connect(l2MessengerImpersonator).rebase(2)
+        L2ECOBridge.connect(l2MessengerImpersonator).rebase(2, 1)
       ).to.be.revertedWith(ERROR_STRINGS.OVM.INVALID_X_DOMAIN_MSG_SENDER)
     })
 
@@ -313,7 +313,7 @@ describe('L2ECOBridge tests', () => {
         DUMMY_L1_BRIDGE_ADDRESS
       )
       await expect(
-        L2ECOBridge.connect(l2MessengerImpersonator).rebase(2)
+        L2ECOBridge.connect(l2MessengerImpersonator).rebase(2, 1)
       ).to.be.revertedWith(ERROR_STRINGS.L2ECO.UNAUTHORIZED_REBASER)
     })
 
@@ -322,7 +322,7 @@ describe('L2ECOBridge tests', () => {
         DUMMY_L1_BRIDGE_ADDRESS
       )
       await expect(
-        L2ECOBridge.connect(l2MessengerImpersonator).rebase(0)
+        L2ECOBridge.connect(l2MessengerImpersonator).rebase(0, 1)
       ).to.be.revertedWith(
         ERROR_STRINGS.L2ECOBridge.INVALID_INFLATION_MULTIPLIER
       )
@@ -335,7 +335,7 @@ describe('L2ECOBridge tests', () => {
       )
 
       await expect(
-        L2ECOBridge.connect(l2MessengerImpersonator).rebase(inflationMultiplier)
+        L2ECOBridge.connect(l2MessengerImpersonator).rebase(inflationMultiplier, 1)
       )
         .to.emit(L2ECOBridge, 'RebaseInitiated')
         .withArgs(inflationMultiplier)

--- a/test/utils/errors.ts
+++ b/test/utils/errors.ts
@@ -19,6 +19,10 @@ export const ERROR_STRINGS = {
     INVALID_L1_ADDRESS: 'L2ECOBridge: invalid L1 token address',
     INVALID_INFLATION_MULTIPLIER: 'L2ECOBridge: invalid inflation multiplier',
     INVALID_EOA_ONLY: 'L2ECOBridge: Account not EOA',
+    INVALID_UPGRADE_ECO_BLOCK:
+      'L2ECOBridge: upgradeEco block number must be greater than last',
+    INVALID_UPGRADE_SELF_BLOCK:
+      'L2ECOBridge: upgradeSelf block number must be greater than last upgrade block',
   },
   L2ECO: {
     UNAUTHORIZED_MINTER: 'L2ECO: not authorized to mint',


### PR DESCRIPTION
adding block number to L1 calls to upgradeEco and upgradeSelf to prevent any replay attacks using failed cross-bridge calls, with test