### PR TITLE
Updated comments about gas variables

### DIFF
--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -186,6 +186,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     /**
      * @inheritdoc IL1ERC20Bridge
      * @param _l1Token must be the ECO L1 token address.
+     * @param _l2Gas The minimum gas limit required for an L2 address finalizing the transation
      */
     function depositERC20(
         address _l1Token,
@@ -208,6 +209,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
     /**
      * @inheritdoc IL1ERC20Bridge
      * @param _l1Token must be the ECO L1 token address.
+     * @param _l2Gas The minimum gas limit required for an L2 address finalizing the transation
      */
     function depositERC20To(
         address _l1Token,

--- a/contracts/bridge/L2ECOBridge.sol
+++ b/contracts/bridge/L2ECOBridge.sol
@@ -116,6 +116,7 @@ contract L2ECOBridge is IL2ECOBridge, CrossDomainEnabledUpgradeable {
 
     /**
      * @inheritdoc IL2ERC20Bridge
+     * @param _l1Gas The minimum gas limit required for an L1 address finalizing the transation
      */
     function withdraw(
         address _l2Token,
@@ -128,6 +129,7 @@ contract L2ECOBridge is IL2ECOBridge, CrossDomainEnabledUpgradeable {
 
     /**
      * @inheritdoc IL2ERC20Bridge
+     * @param _l1Gas The minimum gas limit required for an L1 address finalizing the transation
      */
     function withdrawTo(
         address _l2Token,

--- a/contracts/bridge/L2ECOBridge.sol
+++ b/contracts/bridge/L2ECOBridge.sol
@@ -223,7 +223,7 @@ contract L2ECOBridge is IL2ECOBridge, CrossDomainEnabledUpgradeable {
      * @param _from Account to pull the withdrawal from on L2.
      * @param _to Account to give the withdrawal to on L1.
      * @param _amount Amount of the token to withdraw.
-     * @param _l1Gas Unused, but included for potential forward compatibility considerations.
+     * @param _l1Gas The minimum gas limit required for an L1 address finalizing the transation
      * @param _data Optional data to forward to L1.
      */
     function _initiateWithdrawal(

--- a/contracts/interfaces/bridge/IL1ECOBridge.sol
+++ b/contracts/interfaces/bridge/IL1ECOBridge.sol
@@ -47,7 +47,7 @@ interface IL1ECOBridge is IL1ERC20Bridge {
      * @dev Upgrades the L2ECO token implementation address by sending
      *      a cross domain message to the L2 Bridge via the L1 Messenger
      * @param _impl L2 contract address.
-     * @param _l2Gas Gas limit for the L2 message.
+     * @param _l2Gas The minimum gas limit required for an L2 address finalizing the transation
      */
     function upgradeECO(address _impl, uint32 _l2Gas) external;
 
@@ -55,7 +55,7 @@ interface IL1ECOBridge is IL1ERC20Bridge {
      * @dev Upgrades the L2ECOBridge implementation address by sending
      *      a cross domain message to the L2 Bridge via the L1 Messenger
      * @param _impl L2 contract address.
-     * @param _l2Gas Gas limit for the L2 message.
+     * @param _l2Gas The minimum gas limit required for an L2 address finalizing the transation
      */
     function upgradeL2Bridge(address _impl, uint32 _l2Gas) external;
 
@@ -67,7 +67,7 @@ interface IL1ECOBridge is IL1ERC20Bridge {
     
     /**
      * @dev initiates the propagation of a linear rebase from L1 to L2
-     * @param _l2Gas Gas limit for the L2 message.
+     * @param _l2Gas The minimum gas limit required for an L2 address finalizing the transation
      */
     function rebase(uint32 _l2Gas) external;
 }


### PR DESCRIPTION
clarified from the pre-bedrock documentation the usage of variables forwarding cross chain gas limits