### PR TITLE
Change bridges to use token inflationMultipliers

### DIFF
--- a/contracts/bridge/L1ECOBridge.sol
+++ b/contracts/bridge/L1ECOBridge.sol
@@ -233,7 +233,7 @@ contract L1ECOBridge is IL1ECOBridge, CrossDomainEnabledUpgradeable {
         uint256 _gonsAmount,
         bytes calldata _data
     ) external onlyFromCrossDomainAccount(l2TokenBridge) {
-        uint256 _amount = _gonsAmount / IECO(_l1Eco).getPastLinearInflation(
+        uint256 _amount = _gonsAmount / IECO(l1Eco).getPastLinearInflation(
             block.number
         );
 

--- a/test/L1ECOBridge.spec.ts
+++ b/test/L1ECOBridge.spec.ts
@@ -469,10 +469,6 @@ describe('L1ECOBridge', () => {
 
   describe('does a rebase', () => {
     it('should fetch the inflation multiplier', async () => {
-      expect(await L1ECOBridge.inflationMultiplier()).to.eq(
-        INITIAL_INFLATION_MULTIPLIER
-      )
-
       const newInflationMultiplier = INITIAL_INFLATION_MULTIPLIER.div(2)
 
       if (alice.provider) {
@@ -484,9 +480,6 @@ describe('L1ECOBridge', () => {
         ])
       }
       await L1ECOBridge.connect(alice).rebase(FINALIZATION_GAS)
-      expect(await L1ECOBridge.inflationMultiplier()).to.eq(
-        newInflationMultiplier
-      )
 
       expect(
         Fake__L1CrossDomainMessenger.sendMessage.getCall(0).args

--- a/test/L2ECOBridge.spec.ts
+++ b/test/L2ECOBridge.spec.ts
@@ -152,7 +152,7 @@ describe('L2ECOBridge tests', () => {
           alice.address,
           bob.address,
           BigNumber.from(depositAmount).mul(
-            await L2ECOBridge.inflationMultiplier()
+            await MOCK_L2ECO.linearInflationMultiplier()
           ),
           NON_NULL_BYTES32,
           {
@@ -216,7 +216,7 @@ describe('L2ECOBridge tests', () => {
             alice.address,
             alice.address,
             BigNumber.from(withdrawAmount).mul(
-              await L2ECOBridge.inflationMultiplier()
+              await MOCK_L2ECO.linearInflationMultiplier()
             ),
             NON_NULL_BYTES32,
           ]
@@ -256,7 +256,7 @@ describe('L2ECOBridge tests', () => {
             alice.address,
             bob.address,
             BigNumber.from(withdrawAmount).mul(
-              await L2ECOBridge.inflationMultiplier()
+              await MOCK_L2ECO.linearInflationMultiplier()
             ),
             NON_NULL_BYTES32,
           ]


### PR DESCRIPTION
If the bridge inflationMultiplier is desynced from the token on the same chain, incorrect messages will be sent. With this change, the source of truth is the token and the bridge trusts it completely for the value.